### PR TITLE
[Print CSS] Set the print CSS for the page header elements.

### DIFF
--- a/src/views/_print.scss
+++ b/src/views/_print.scss
@@ -7,3 +7,24 @@
 /*
   @title: Print view
  */
+%theme-ogpl-print-display-none-important {
+	display: none !important;
+}
+
+#wb-glb-mn {
+	@extend %theme-ogpl-print-display-none-important;
+}
+
+#wb-bc {
+	.breadcrumb {
+		margin-bottom: 0;
+	}
+	
+	a[href]:after {
+		content: "";
+	}
+}
+ 
+h1 {
+	margin-top: 0;
+}


### PR DESCRIPTION
To reduce the amount of space taken up by the document header when printing.
