### PR TITLE
Secondary menu: Fix hover issue for contrast ratio on base theme.

### DIFF
--- a/src/views/_screen-md-min.scss
+++ b/src/views/_screen-md-min.scss
@@ -133,7 +133,7 @@ body {
 }
 
 %secmenu-ogpl-theme-menuitem-curr-hover-focus {
-	background: darken($clrWhite, 50%);
+	background: darken($clrWhite, 60%);
 	color: lighten($clrDark, 75%);
 }
 


### PR DESCRIPTION
Contrast ratio fails at 3.0:1, fixed to 60% and achieves 5.7:1.