### PR TITLE
Theme: Reworked main background colour variable into a content area one.

### DIFF
--- a/src/_variables.scss
+++ b/src/_variables.scss
@@ -8,8 +8,8 @@
 // Body
 $body-bg: #eee; // Body element's background colour (Bootstrap override).
 
-// Main
-$main-bg: #fff; // Main element's background colour (WET override).
+// Content area
+$content-bg: #fff; // Content area's background colour (WET override).
 
 $banner-gradient-start: #4065b3;
 $banner-gradient-end: #33479e;

--- a/src/views/_screen-md-min.scss
+++ b/src/views/_screen-md-min.scss
@@ -16,18 +16,6 @@
 	border-bottom: 1px solid #fff;
 }
 
-body {
-	> {
-		header {
-			+ {
-				.container {
-					background-color: $main-bg;
-				}
-			}
-		}
-	}
-}
-
 #ogpl-logo {
 	padding: 10px 0;
 }


### PR DESCRIPTION
* Renames the $main-bg variable to $content-bg.
* Removes redundant code that used to set the content container's background colour. It's now built-into wet-boew via wet-boew/wet-boew#7920.
* Depends on wet-boew/wet-boew#7920.