### PR TITLE
Build: Updated grunt-gh-pages to version ~2.0.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "grunt-contrib-uglify": "~0.5.1",
     "grunt-contrib-watch": "~0.6.1",
     "grunt-cssmin-ie8-clean": "0.0.1",
-    "grunt-gh-pages": "~0.9.0",
+    "grunt-gh-pages": "~2.0.0",
     "grunt-html": "^5.0.0",
     "grunt-hub": "~0.7.0",
     "grunt-install-dependencies": "~0.2.0",


### PR DESCRIPTION
All 1.x versions of it use a dependency called wrench, which is incompatible with node.js >=7.x. Starting with version 2.0.0, its wrench dependency has been replaced with fs-extra (which works properly in node.js >=7.x).