### PR TITLE
Theme index: Revised link text to end with page languages.

### DIFF
--- a/site/pages/index-en.hbs
+++ b/site/pages/index-en.hbs
@@ -21,24 +21,24 @@
 <section>
 	<h2 id="{{lang-code}}">{{lang-en}}</h2>
 	<ul>
-		<li><a href="content-{{lang-code}}.html">Content page</a></li>
-		<li><a href="content-secmenu-{{lang-code}}.html">Content page - Secondary menu</a></li>
-		<li><a href="content-nosearchlang-{{lang-code}}.html">Content page - No search or language selection link</a></li>
-		<li><a href="content-nositemenubc-{{lang-code}}.html">Content page - No site menu or breadcrumb trail</a></li>
-		<li><a href="content-nosearchlangsitemenubc-{{lang-code}}.html">Content page - No search, language selection link, site menu or breadcrumb trail</a></li>
+		<li><a href="content-{{lang-code}}.html">Content page<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="content-secmenu-{{lang-code}}.html">Content page - Secondary menu<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="content-nosearchlang-{{lang-code}}.html">Content page - No search or language selection link<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="content-nositemenubc-{{lang-code}}.html">Content page - No site menu or breadcrumb trail<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="content-nosearchlangsitemenubc-{{lang-code}}.html">Content page - No search, language selection link, site menu or breadcrumb trail<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
 		{{#is lang-code "en"}}
-		<li><a href="splashpage-en.html">Splash page</a></li>
-		<li><a href="404-en.html">404 error page</a></li>
-		<li><a href="404-en-fr.html">404 error page (English/French)</a></li>
-		<li><a href="servermessage-en-fr.html">Server message page (English/French)</a></li>
+		<li><a href="splashpage-en.html">Splash page<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="404-en.html">404 error page<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="404-en-fr.html">404 error page - English/French</a></li>
+		<li><a href="servermessage-en-fr.html">Server message page - English/French</a></li>
 		{{/is}}
 		{{#is lang-code "fr"}}
-		<li><a href="splashpage-fr.html">Splash page</a></li>
-		<li><a href="404-fr.html">404 error page</a></li>
-		<li><a href="404-fr-en.html">404 error page (French/English)</a></li>
-		<li><a href="servermessage-fr-en.html">Server message page (French/English)</a></li>
+		<li><a href="splashpage-fr.html">Splash page<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="404-fr.html">404 error page<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
+		<li><a href="404-fr-en.html">404 error page - French/English</a></li>
+		<li><a href="servermessage-fr-en.html">Server message page - French/English</a></li>
 		{{/is}}
-		<li><a href="servermessage-{{lang-code}}.html">Server message page</a></li>
+		<li><a href="servermessage-{{lang-code}}.html">Server message page<span class="wb-inv"> - {{"lang-en"}}</span></a></li>
 	</ul>
 </section>
 {{/withSort}}

--- a/site/pages/index-fr.hbs
+++ b/site/pages/index-fr.hbs
@@ -21,24 +21,24 @@
 <section>
 	<h2 id="{{lang-code}}">{{lang-fr}}</h2>
 	<ul>
-		<li><a href="content-{{lang-code}}.html">Page de contenu</a></li>
-		<li><a href="content-secmenu-{{lang-code}}.html">Page de contenu - Menu secondaire</a></li>
-		<li><a href="content-nosearchlang-{{lang-code}}.html">Page de contenu - Sans recherche ou lien de sélection de la langue</a></li>
-		<li><a href="content-nositemenubc-{{lang-code}}.html">Page de contenu - Sans menu du site ou fil d'Ariane</a></li>
-		<li><a href="content-nosearchlangsitemenubc-{{lang-code}}.html">Page de contenu - Sans recherche, lien de sélection de la langue, menu du site ou fil d'Ariane</a></li>
+		<li><a href="content-{{lang-code}}.html">Page de contenu<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="content-secmenu-{{lang-code}}.html">Page de contenu - Menu secondaire<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="content-nosearchlang-{{lang-code}}.html">Page de contenu - Sans recherche ou lien de sélection de la langue<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="content-nositemenubc-{{lang-code}}.html">Page de contenu - Sans menu du site ou fil d'Ariane<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="content-nosearchlangsitemenubc-{{lang-code}}.html">Page de contenu - Sans recherche, lien de sélection de la langue, menu du site ou fil d'Ariane<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
 		{{#is lang-code "en"}}
-		<li><a href="splashpage-en.html">Page d'entrée</a></li>
-		<li><a href="404-en.html">Page d'erreur 404</a></li>
-		<li><a href="404-en-fr.html">Page d'erreur 404 (anglais/français)</a></li>
-		<li><a href="servermessage-en-fr.html">Page de message du serveur (anglais/français)</a></li>
+		<li><a href="splashpage-en.html">Page d'entrée<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="404-en.html">Page d'erreur 404<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="404-en-fr.html">Page d'erreur 404 - anglais/français</a></li>
+		<li><a href="servermessage-en-fr.html">Page de message du serveur - anglais/français</a></li>
 		{{/is}}
 		{{#is lang-code "fr"}}
-		<li><a href="splashpage-fr.html">Page d'entrée</a></li>
-		<li><a href="404-fr.html">Page d'erreur 404</a></li>
-		<li><a href="404-fr-en.html">Page d'erreur 404 (anglais/français)</a></li>
-		<li><a href="servermessage-fr-en.html">Page de message du serveur (français/anglais)</a></li>
+		<li><a href="splashpage-fr.html">Page d'entrée<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="404-fr.html">Page d'erreur 404<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
+		<li><a href="404-fr-en.html">Page d'erreur 404 - anglais/français</a></li>
+		<li><a href="servermessage-fr-en.html">Page de message du serveur - français/anglais</a></li>
 		{{/is}}
-		<li><a href="servermessage-{{lang-code}}.html">Page de message du serveur</a></li>
+		<li><a href="servermessage-{{lang-code}}.html">Page de message du serveur<span class="wb-inv"> - {{"lang-fr"}}</span></a></li>
 	</ul>
 </section>
 {{/withSort}}


### PR DESCRIPTION
* Added hidden link text containing " - [Language]" to the end of all page template links. This makes each link's text unique, which can benefit screen reader users that may encounter them out of context.
* Revised the bilingual 404 error and server message page's links to end with " - [Language]/[Language]" (instead of " ([Language]/[Language])") for consistency.
* Related to wet-boew/wet-boew#7990.