### PR TITLE
Theme: Fixed most broken links.

### DIFF
--- a/site/includes/footercontent.hbs
+++ b/site/includes/footercontent.hbs
@@ -8,8 +8,8 @@
 <section class="col-sm-3">
 	<h3>{{{i18n "site-about"}}}</h3>
 	<ul class="list-unstyled">
-		<li><a href="http//ogpl.github.io/about/governance-{{language}}.html">{{{i18n "site-governance"}}}</a></li>
-		<li><a href="http//ogpl.github.io/about/licensing-{{language}}.html">{{{i18n "site-licenses"}}}</a></li>
+		<li><a href="http://ogpl.github.io/about/governance-{{language}}.html">{{{i18n "site-governance"}}}</a></li>
+		<li><a href="http://ogpl.github.io/about/licensing-{{language}}.html">{{{i18n "site-licenses"}}}</a></li>
 	</ul>
 </section>
 <section class="col-sm-3">

--- a/site/includes/sitemenucontent.hbs
+++ b/site/includes/sitemenucontent.hbs
@@ -1,7 +1,7 @@
 {{#unless page.altMenu}}
-	<li><a href="http://ogpl.github.io/best_practices/index-{{language}}/index-{{language}}.html">{{{i18n "best-practices"}}}</a></li>
+	<li><a href="http://ogpl.github.io/best-practices/index-{{language}}.html">{{{i18n "best-practices"}}}</a></li>
 	<li><a href="http://ogpl.github.io/contributions/index-{{language}}.html#implement">{{{i18n "contributions"}}}</a></li>
-	<li><a href="http://ogpl.github.io/open_data/index-{{language}}.html">{{{i18n "open-data"}}}</a></li>
+	<li><a href="http://ogpl.github.io/open-data/index-{{language}}.html">{{{i18n "open-data"}}}</a></li>
 	<li><a href="http://ogpl.github.io/partners/index-{{language}}.html">{{{i18n "partners"}}}</a></li>
 	<li><a href="http://ogpl.github.io/tools/index-{{language}}.html">{{{i18n "tools"}}}</a></li>
 {{else}}

--- a/site/pages/404-en-fr.hbs
+++ b/site/pages/404-en-fr.hbs
@@ -11,7 +11,7 @@
 	<h2><span class="glyphicon glyphicon-warning-sign mrgn-rght-md"></span> We couldn't find that Web page (Error 404)</h2>
 	<p>We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for.</p>
 	<ul>
-		<li>Return to the <a href="/v4.0-ci/index-en.html">home page</a></li>
+		<li>Return to the <a href="http://wet-boew.github.io/v4.0-ci/index-en.html">home page</a></li>
 	</ul>
 </section>
 
@@ -19,6 +19,6 @@
 	<h2><span class="glyphicon glyphicon-warning-sign mrgn-rght-md"></span> Nous ne pouvons trouver cette page Web (Erreur 404)</h2>
 	<p>Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez.</p>
 	<ul>
-		<li>Retournez à la <a href="/v4.0-ci/index-fr.html">page d'accueil</a></li>
+		<li>Retournez à la <a href="http://wet-boew.github.io/v4.0-ci/index-fr.html">page d'accueil</a></li>
 	</ul>
 </section>

--- a/site/pages/404-en.hbs
+++ b/site/pages/404-en.hbs
@@ -9,6 +9,6 @@
 	<h1><span class="glyphicon glyphicon-warning-sign mrgn-rght-md"></span> {{{i18n "tmpl-msg-title"}}}</h1>
 	<p>We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for.</p>
 	<ul>
-		<li>Return to the <a href="/v4.0-ci/index-en.html">home page</a></li>
+		<li>Return to the <a href="http://wet-boew.github.io/v4.0-ci/index-en.html">home page</a></li>
 	</ul>
 </div>

--- a/site/pages/404-fr-en.hbs
+++ b/site/pages/404-fr-en.hbs
@@ -11,7 +11,7 @@
 	<h2><span class="glyphicon glyphicon-warning-sign mrgn-rght-md"></span> Nous ne pouvons trouver cette page Web (Erreur 404)</h2>
 	<p>Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez.</p>
 	<ul>
-		<li>Retournez à la <a href="/v4.0-ci/index-fr.html">page d'accueil</a></li>
+		<li>Retournez à la <a href="http://wet-boew.github.io/v4.0-ci/index-fr.html">page d'accueil</a></li>
 	</ul>
 </section>
 
@@ -19,6 +19,6 @@
 	<h2><span class="glyphicon glyphicon-warning-sign mrgn-rght-md"></span> We couldn't find that Web page (Error 404)</h2>
 	<p>We're sorry you ended up here. Sometimes a page gets moved or deleted, but hopefully we can help you find what you're looking for.</p>
 	<ul>
-		<li>Return to the <a href="/v4.0-ci/index-en.html">home page</a></li>
+		<li>Return to the <a href="http://wet-boew.github.io/v4.0-ci/index-en.html">home page</a></li>
 	</ul>
 </section>

--- a/site/pages/404-fr.hbs
+++ b/site/pages/404-fr.hbs
@@ -9,6 +9,6 @@
 	<h1><span class="glyphicon glyphicon-warning-sign mrgn-rght-md"></span> Nous ne pouvons trouver cette page Web (Erreur 404)</h1>
 	<p>Nous sommes désolés que vous ayez abouti ici. Il arrive parfois qu'une page ait été déplacée ou supprimée. Heureusement, nous pouvons vous aider à trouver ce que vous cherchez.</p>
 	<ul>
-		<li>Retournez à la <a href="/v4.0-ci/index-fr.html">page d'accueil</a></li>
+		<li>Retournez à la <a href="http://wet-boew.github.io/v4.0-ci/index-fr.html">page d'accueil</a></li>
 	</ul>
 </div>

--- a/site/pages/splashpage-en.hbs
+++ b/site/pages/splashpage-en.hbs
@@ -11,7 +11,7 @@
 	<h2 class="h3 text-center">Open Government Platform (OGPL) theme - Web Experience Toolkit</h2>
 	<ul class="list-unstyled">
 		<li><a class="btn btn-lg btn-primary btn-block" href="../index-en.html">English</a></li>
-		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="../../License-en.html" rel="license">Terms and conditions of use</a></li>
+		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="http://wet-boew.github.io/v4.0-ci/License-en.html" rel="license">Terms and conditions of use</a></li>
 	</ul>
 </section>
 
@@ -19,6 +19,6 @@
 	<h2 class="h3 text-center">Thème de la Plate-forme de gouvernement ouvert (PGO) - Boîte à outils de l’expérience Web</h2>
 	<ul class="list-unstyled">
 		<li><a class="btn btn-lg btn-primary btn-block" href="../index-fr.html">Français</a></li>
-		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="../../Licence-fr.html" rel="license">Conditions régissant l'utilisation</a></li>
+		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="http://wet-boew.github.io/v4.0-ci/Licence-fr.html" rel="license">Conditions régissant l'utilisation</a></li>
 	</ul>
 </section>

--- a/site/pages/splashpage-fr.hbs
+++ b/site/pages/splashpage-fr.hbs
@@ -11,7 +11,7 @@
 	<h2 class="h3 text-center">Thème de la Plate-forme de gouvernement ouvert (PGO) - Boîte à outils de l’expérience Web</h2>
 	<ul class="list-unstyled">
 		<li><a class="btn btn-lg btn-primary btn-block" href="../index-fr.html">Français</a></li>
-		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="../../Licence-fr.html" rel="license">Conditions régissant l'utilisation</a></li>
+		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="http://wet-boew.github.io/v4.0-ci/Licence-fr.html" rel="license">Conditions régissant l'utilisation</a></li>
 	</ul>
 </section>
 
@@ -19,6 +19,6 @@
 	<h2 class="h3 text-center">Open Government Platform (OGPL) theme - Web Experience Toolkit</h2>
 	<ul class="list-unstyled">
 		<li><a class="btn btn-lg btn-primary btn-block" href="../index-en.html">English</a></li>
-		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="../../License-en.html" rel="license">Terms and conditions of use</a></li>
+		<li><a class="btn btn-lg btn-default btn-block mrgn-tp-sm" href="http://wet-boew.github.io/v4.0-ci/License-en.html" rel="license">Terms and conditions of use</a></li>
 	</ul>
 </section>


### PR DESCRIPTION
The only remaining broken link is called "Contact Us form (ogpl.gov.in)"/"Formulaire contactez-nous (ogpl.gov.in)". It points to http://ogpl.gov.in/contactus, which returns an HTTP 403 error.